### PR TITLE
Add link to official GitHub repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ LeechBlock
 This is not the primary repo. I just needed a sane way to hack on this and keep
 track of progress while things are in progress.
 
+The official LeechBlock GitHub repo is here:
+
+https://github.com/proginosko/LeechBlock
+
 If you would like to download the add-on you should see it here_: 
 
 .. _here: https://addons.mozilla.org/en-us/firefox/addon/leechblock/


### PR DESCRIPTION
This repo is currently the first result for 'leechblock github' on Google. The official repo isn't even on the first results page.
